### PR TITLE
Switch to concurrent-hash-map 0.0.6

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,14 +24,11 @@ chan-signal = "0.1.6"
 log = "0.3.6"
 syslog = "3.1.0"
 chrono = "0.2.22"
+concurrent-hash-map = "0.0.6"
 
 [dependencies.scheduler]
 git = "https://github.com/polachok/rust-scheduler"
 branch = "portability"
-
-[dependencies.concurrent-hash-map]
-git = "https://github.com/polachok/concurrent-hash-map"
-branch = "hasher"
 
 [dependencies.influent]
 git = "https://github.com/polachok/influent.rs"


### PR DESCRIPTION
 Our changes were merged into upstream
